### PR TITLE
Add a few missing pulls missing issue data

### DIFF
--- a/issues/74xx/7487.json
+++ b/issues/74xx/7487.json
@@ -1,0 +1,76 @@
+{
+  "url": "https://api.github.com/repos/bitcoin/bitcoin/issues/7487",
+  "repository_url": "https://api.github.com/repos/bitcoin/bitcoin",
+  "labels_url": "https://api.github.com/repos/bitcoin/bitcoin/issues/7487/labels{/name}",
+  "comments_url": "https://api.github.com/repos/bitcoin/bitcoin/issues/7487/comments",
+  "events_url": "https://api.github.com/repos/bitcoin/bitcoin/issues/7487/events",
+  "html_url": "https://github.com/bitcoin/bitcoin/pull/7487",
+  "id": 132326386,
+  "number": 7487,
+  "title": "Workaround Travis-side CI issues",
+  "user": {
+    "login": "luke-jr",
+    "id": 1095675,
+    "avatar_url": "https://avatars.githubusercontent.com/u/1095675?v=3",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/luke-jr",
+    "html_url": "https://github.com/luke-jr",
+    "followers_url": "https://api.github.com/users/luke-jr/followers",
+    "following_url": "https://api.github.com/users/luke-jr/following{/other_user}",
+    "gists_url": "https://api.github.com/users/luke-jr/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/luke-jr/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/luke-jr/subscriptions",
+    "organizations_url": "https://api.github.com/users/luke-jr/orgs",
+    "repos_url": "https://api.github.com/users/luke-jr/repos",
+    "events_url": "https://api.github.com/users/luke-jr/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/luke-jr/received_events",
+    "type": "User",
+    "site_admin": false
+  },
+  "labels": [
+    {
+      "url": "https://api.github.com/repos/bitcoin/bitcoin/labels/Build%20system",
+      "name": "Build system",
+      "color": "5319e7"
+    },
+    {
+      "url": "https://api.github.com/repos/bitcoin/bitcoin/labels/Tests",
+      "name": "Tests",
+      "color": "d4c5f9"
+    }
+  ],
+  "state": "closed",
+  "locked": false,
+  "assignee": null,
+  "milestone": null,
+  "comments": 11,
+  "created_at": "2016-02-09T04:05:32Z",
+  "updated_at": "2016-02-15T11:57:15Z",
+  "closed_at": "2016-02-15T11:57:15Z",
+  "pull_request": {
+    "url": "https://api.github.com/repos/bitcoin/bitcoin/pulls/7487",
+    "html_url": "https://github.com/bitcoin/bitcoin/pull/7487",
+    "diff_url": "https://github.com/bitcoin/bitcoin/pull/7487.diff",
+    "patch_url": "https://github.com/bitcoin/bitcoin/pull/7487.patch"
+  },
+  "body": "Currently Travis's wget fails fetching qrencode:\r\n\r\n```\r\nFetching qrencode...\r\nERROR: no certificate subject alternative name matches\r\n\trequested host name `fukuchi.org'.\r\nTo connect to fukuchi.org insecurely, use `--no-check-certificate'.\r\nOpenSSL: error:14077438:SSL routines:SSL23_GET_SERVER_HELLO:tlsv1 alert internal error\r\nUnable to establish SSL connection.\r\nmake: *** [/home/travis/build/luke-jr/bitcoin/depends/sources/download-stamps/.stamp_fetched-qrencode-qrencode-3.4.4.tar.bz2.hash] Error 4\r\n```",
+  "closed_by": {
+    "login": "laanwj",
+    "id": 126646,
+    "avatar_url": "https://avatars.githubusercontent.com/u/126646?v=3",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/laanwj",
+    "html_url": "https://github.com/laanwj",
+    "followers_url": "https://api.github.com/users/laanwj/followers",
+    "following_url": "https://api.github.com/users/laanwj/following{/other_user}",
+    "gists_url": "https://api.github.com/users/laanwj/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/laanwj/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/laanwj/subscriptions",
+    "organizations_url": "https://api.github.com/users/laanwj/orgs",
+    "repos_url": "https://api.github.com/users/laanwj/repos",
+    "events_url": "https://api.github.com/users/laanwj/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/laanwj/received_events",
+    "type": "User",
+    "site_admin": false
+  }
+}

--- a/issues/76xx/7614.json
+++ b/issues/76xx/7614.json
@@ -1,0 +1,76 @@
+{
+  "url": "https://api.github.com/repos/bitcoin/bitcoin/issues/7614",
+  "repository_url": "https://api.github.com/repos/bitcoin/bitcoin",
+  "labels_url": "https://api.github.com/repos/bitcoin/bitcoin/issues/7614/labels{/name}",
+  "comments_url": "https://api.github.com/repos/bitcoin/bitcoin/issues/7614/comments",
+  "events_url": "https://api.github.com/repos/bitcoin/bitcoin/issues/7614/events",
+  "html_url": "https://github.com/bitcoin/bitcoin/pull/7614",
+  "id": 136884166,
+  "number": 7614,
+  "title": "Bugfix: gitian: Add curl to packages (now needed for depends)",
+  "user": {
+    "login": "luke-jr",
+    "id": 1095675,
+    "avatar_url": "https://avatars.githubusercontent.com/u/1095675?v=3",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/luke-jr",
+    "html_url": "https://github.com/luke-jr",
+    "followers_url": "https://api.github.com/users/luke-jr/followers",
+    "following_url": "https://api.github.com/users/luke-jr/following{/other_user}",
+    "gists_url": "https://api.github.com/users/luke-jr/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/luke-jr/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/luke-jr/subscriptions",
+    "organizations_url": "https://api.github.com/users/luke-jr/orgs",
+    "repos_url": "https://api.github.com/users/luke-jr/repos",
+    "events_url": "https://api.github.com/users/luke-jr/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/luke-jr/received_events",
+    "type": "User",
+    "site_admin": false
+  },
+  "labels": [
+    {
+      "url": "https://api.github.com/repos/bitcoin/bitcoin/labels/Build%20system",
+      "name": "Build system",
+      "color": "5319e7"
+    },
+    {
+      "url": "https://api.github.com/repos/bitcoin/bitcoin/labels/Needs%20backport",
+      "name": "Needs backport",
+      "color": "ff8200"
+    }
+  ],
+  "state": "closed",
+  "locked": false,
+  "assignee": null,
+  "milestone": null,
+  "comments": 5,
+  "created_at": "2016-02-27T06:11:20Z",
+  "updated_at": "2016-03-01T14:08:08Z",
+  "closed_at": "2016-03-01T14:08:04Z",
+  "pull_request": {
+    "url": "https://api.github.com/repos/bitcoin/bitcoin/pulls/7614",
+    "html_url": "https://github.com/bitcoin/bitcoin/pull/7614",
+    "diff_url": "https://github.com/bitcoin/bitcoin/pull/7614.diff",
+    "patch_url": "https://github.com/bitcoin/bitcoin/pull/7614.patch"
+  },
+  "body": "",
+  "closed_by": {
+    "login": "laanwj",
+    "id": 126646,
+    "avatar_url": "https://avatars.githubusercontent.com/u/126646?v=3",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/laanwj",
+    "html_url": "https://github.com/laanwj",
+    "followers_url": "https://api.github.com/users/laanwj/followers",
+    "following_url": "https://api.github.com/users/laanwj/following{/other_user}",
+    "gists_url": "https://api.github.com/users/laanwj/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/laanwj/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/laanwj/subscriptions",
+    "organizations_url": "https://api.github.com/users/laanwj/orgs",
+    "repos_url": "https://api.github.com/users/laanwj/repos",
+    "events_url": "https://api.github.com/users/laanwj/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/laanwj/received_events",
+    "type": "User",
+    "site_admin": false
+  }
+}

--- a/issues/76xx/7617.json
+++ b/issues/76xx/7617.json
@@ -1,0 +1,71 @@
+{
+  "url": "https://api.github.com/repos/bitcoin/bitcoin/issues/7617",
+  "repository_url": "https://api.github.com/repos/bitcoin/bitcoin",
+  "labels_url": "https://api.github.com/repos/bitcoin/bitcoin/issues/7617/labels{/name}",
+  "comments_url": "https://api.github.com/repos/bitcoin/bitcoin/issues/7617/comments",
+  "events_url": "https://api.github.com/repos/bitcoin/bitcoin/issues/7617/events",
+  "html_url": "https://github.com/bitcoin/bitcoin/pull/7617",
+  "id": 136943303,
+  "number": 7617,
+  "title": "[doc/log] Fix markdown syntax and line terminate LogPrint",
+  "user": {
+    "login": "MarcoFalke",
+    "id": 6399679,
+    "avatar_url": "https://avatars.githubusercontent.com/u/6399679?v=3",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/MarcoFalke",
+    "html_url": "https://github.com/MarcoFalke",
+    "followers_url": "https://api.github.com/users/MarcoFalke/followers",
+    "following_url": "https://api.github.com/users/MarcoFalke/following{/other_user}",
+    "gists_url": "https://api.github.com/users/MarcoFalke/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/MarcoFalke/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/MarcoFalke/subscriptions",
+    "organizations_url": "https://api.github.com/users/MarcoFalke/orgs",
+    "repos_url": "https://api.github.com/users/MarcoFalke/repos",
+    "events_url": "https://api.github.com/users/MarcoFalke/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/MarcoFalke/received_events",
+    "type": "User",
+    "site_admin": false
+  },
+  "labels": [
+    {
+      "url": "https://api.github.com/repos/bitcoin/bitcoin/labels/Docs%20and%20Output",
+      "name": "Docs and Output",
+      "color": "02d7e1"
+    }
+  ],
+  "state": "closed",
+  "locked": false,
+  "assignee": null,
+  "milestone": null,
+  "comments": 4,
+  "created_at": "2016-02-27T17:21:26Z",
+  "updated_at": "2016-03-01T18:33:56Z",
+  "closed_at": "2016-03-01T17:39:36Z",
+  "pull_request": {
+    "url": "https://api.github.com/repos/bitcoin/bitcoin/pulls/7617",
+    "html_url": "https://github.com/bitcoin/bitcoin/pull/7617",
+    "diff_url": "https://github.com/bitcoin/bitcoin/pull/7617.diff",
+    "patch_url": "https://github.com/bitcoin/bitcoin/pull/7617.patch"
+  },
+  "body": "* Fix three minor issues in the 0.12 historical release notes.\r\n* Fix some links\r\n* Yet another  #6497",
+  "closed_by": {
+    "login": "laanwj",
+    "id": 126646,
+    "avatar_url": "https://avatars.githubusercontent.com/u/126646?v=3",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/laanwj",
+    "html_url": "https://github.com/laanwj",
+    "followers_url": "https://api.github.com/users/laanwj/followers",
+    "following_url": "https://api.github.com/users/laanwj/following{/other_user}",
+    "gists_url": "https://api.github.com/users/laanwj/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/laanwj/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/laanwj/subscriptions",
+    "organizations_url": "https://api.github.com/users/laanwj/orgs",
+    "repos_url": "https://api.github.com/users/laanwj/repos",
+    "events_url": "https://api.github.com/users/laanwj/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/laanwj/received_events",
+    "type": "User",
+    "site_admin": false
+  }
+}

--- a/issues/77xx/7780.json
+++ b/issues/77xx/7780.json
@@ -1,0 +1,71 @@
+{
+  "url": "https://api.github.com/repos/bitcoin/bitcoin/issues/7780",
+  "repository_url": "https://api.github.com/repos/bitcoin/bitcoin",
+  "labels_url": "https://api.github.com/repos/bitcoin/bitcoin/issues/7780/labels{/name}",
+  "comments_url": "https://api.github.com/repos/bitcoin/bitcoin/issues/7780/comments",
+  "events_url": "https://api.github.com/repos/bitcoin/bitcoin/issues/7780/events",
+  "html_url": "https://github.com/bitcoin/bitcoin/pull/7780",
+  "id": 144997985,
+  "number": 7780,
+  "title": "[0.12] Disable bad-chain alert",
+  "user": {
+    "login": "btcdrak",
+    "id": 7275704,
+    "avatar_url": "https://avatars.githubusercontent.com/u/7275704?v=3",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/btcdrak",
+    "html_url": "https://github.com/btcdrak",
+    "followers_url": "https://api.github.com/users/btcdrak/followers",
+    "following_url": "https://api.github.com/users/btcdrak/following{/other_user}",
+    "gists_url": "https://api.github.com/users/btcdrak/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/btcdrak/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/btcdrak/subscriptions",
+    "organizations_url": "https://api.github.com/users/btcdrak/orgs",
+    "repos_url": "https://api.github.com/users/btcdrak/repos",
+    "events_url": "https://api.github.com/users/btcdrak/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/btcdrak/received_events",
+    "type": "User",
+    "site_admin": false
+  },
+  "labels": [
+    {
+      "url": "https://api.github.com/repos/bitcoin/bitcoin/labels/Bug",
+      "name": "Bug",
+      "color": "FBBAAB"
+    }
+  ],
+  "state": "closed",
+  "locked": false,
+  "assignee": null,
+  "milestone": null,
+  "comments": 4,
+  "created_at": "2016-03-31T19:40:34Z",
+  "updated_at": "2016-04-01T12:17:17Z",
+  "closed_at": "2016-04-01T12:16:59Z",
+  "pull_request": {
+    "url": "https://api.github.com/repos/bitcoin/bitcoin/pulls/7780",
+    "html_url": "https://github.com/bitcoin/bitcoin/pull/7780",
+    "diff_url": "https://github.com/bitcoin/bitcoin/pull/7780.diff",
+    "patch_url": "https://github.com/bitcoin/bitcoin/pull/7780.patch"
+  },
+  "body": "Continuous false positives will lead to them being ignored entirely.\r\nBetter to disable now until this can be fixed more thoroughly in the next release.\r\n\r\nDiscussed at 2016-03-31 IRC meeting.\r\n\r\nRefs: #7568",
+  "closed_by": {
+    "login": "laanwj",
+    "id": 126646,
+    "avatar_url": "https://avatars.githubusercontent.com/u/126646?v=3",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/laanwj",
+    "html_url": "https://github.com/laanwj",
+    "followers_url": "https://api.github.com/users/laanwj/followers",
+    "following_url": "https://api.github.com/users/laanwj/following{/other_user}",
+    "gists_url": "https://api.github.com/users/laanwj/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/laanwj/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/laanwj/subscriptions",
+    "organizations_url": "https://api.github.com/users/laanwj/orgs",
+    "repos_url": "https://api.github.com/users/laanwj/repos",
+    "events_url": "https://api.github.com/users/laanwj/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/laanwj/received_events",
+    "type": "User",
+    "site_admin": false
+  }
+}


### PR DESCRIPTION
Some PRs have a 'base' issue file, some have not. For example #7606 has `7606.json`, `7606-PR.json`  however #7617 only has `7617-PR.json` (both have `-comments.json`).

Add a few of these in manually.

Is there a reason for this? I have a local script that sorts pulls by labels, but -PR.json doesn't have these, so it's useful to have the base files for pulls as well.