### PR TITLE
Missing pull-request review comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ issue 1234:
  * `issues/12xx/1234-comments.json` is all comments, both issue comments and PR
    review comments, in `created_at` order (so, a mixture of the
    [`/repos/:owner/:repo/issues/:number/comments`][comments] and
-   [`/repos/:owner/:repo/pulls/:number/comments`][reviews] endpoints)
+   [`/repos/:owner/:repo/pulls/:number/comments`][reviews] endpoints). However,
+   **review-comments are missing** from the backups. See #6 for more details.
 
 Note that issue descriptions are rendered as the first comment by GitHub's web
 interface but are seen as properties of the issues by the GitHub API, and


### PR DESCRIPTION
Upon closer inspection, it turns out that review-comments are missing from the backup. As issues are disabled on this repository, I'm adding a note to the README.md with a reference to this PR to document this.

An example is this "approve" by fanquake in 25723: https://github.com/bitcoin/bitcoin/pull/25723#pullrequestreview-1053237755. The PR does not have any other comments besides this ACK and in the zw/bitcoin-gh-meta backup only the `25723-PR.json` and `25723.json` files exist. The [25723-comments.json](https://github.com/zw/bitcoin-gh-meta/blob/ae2d5d364403a50d95fdfba113a91e911987020b/issues/257xx/25723-comments.json) does not exist.

I this case, the comment "only" contains an `ACK <hash>` (which is important information if someone needs to go back and see who reviewed this PR). In other cases it might be a detailed description of the review and other approaches considered. I think it's important that these pull-request reviews are included. 

My guess is that this is a feature GitHub introduced in the last 9 years and it's not queried by the ghrip tool (last changed 9 years ago). While I got the ghrip tool running and did a full backup with it, I wasn't too keen on working my way through it to add that functionality. 
 